### PR TITLE
Update reference to official image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #You can use this directly as your mssql-container, or just use it to create the nodirect_open.so file
 #for using with an existing container like shown in docker-compose.yml
-FROM store/microsoft/mssql-server-linux:2017-latest
+FROM mcr.microsoft.com/mssql/server:2017-latest
 ADD nodirect_open.c /
 RUN apt update && apt install -y gcc && \
 gcc -shared -fpic -o /nodirect_open.so nodirect_open.c -ldl && \


### PR DESCRIPTION
Hi,

not entirely sure if I was doing something wrong - but I had to update the link to the official image in order to be able to pull it down without logging in - and so build my own local copy.

Looks like the image has moved from Docker servers/registry to Microsoft servers/registry?